### PR TITLE
Fix Send button not sending every other click

### DIFF
--- a/app/src/main/java/com/google/ai/edge/aicore/demo/kotlin/MainActivity.kt
+++ b/app/src/main/java/com/google/ai/edge/aicore/demo/kotlin/MainActivity.kt
@@ -141,6 +141,7 @@ class MainActivity : AppCompatActivity(), GenerationConfigDialog.OnConfigUpdateL
           contentAdapter.addContent(ContentAdapter.VIEW_TYPE_RESPONSE_ERROR, e.message!!)
           endGeneratingUi()
         }
+        inGenerating = false
       }
   }
 


### PR DESCRIPTION
Your inGenerating flag does not reset back to false when generation finishes or errors. So every other Send click is actually treated as a "Cancel" click but says "Send".

Reproduce by sending "Hi" twice. The second "send" button click does nothing.