### PR TITLE
[jules] Update to use Firebase AI Logic SDK

### DIFF
--- a/ai-catalog/app/build.gradle.kts
+++ b/ai-catalog/app/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.vertexai)
+    implementation(libs.firebase.ai)
     ksp(libs.hilt.compiler)
 
     implementation(project(":samples:gemini-multimodal"))

--- a/ai-catalog/gradle/libs.versions.toml
+++ b/ai-catalog/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.8.0"
 coilCompose = "3.1.0"
-firebaseBom = "33.12.0"
+firebaseBom = "33.14.0"
 mlkitGenAi = "1.0.0-beta1"
 kotlin = "2.1.0"
 coreKtx = "1.15.0"
@@ -31,7 +31,7 @@ uiToolingPreviewAndroid = "1.8.1"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
-firebase-vertexai = { group = "com.google.firebase", name = "firebase-vertexai" }
+firebase-ai = { module = "com.google.firebase:firebase-ai" }
 firebase-common-ktx = { group = "com.google.firebase", name = "firebase-common-ktx", version.ref = "firebaseCommonKtx" }
 genai-image-description = { module = "com.google.mlkit:genai-image-description", version.ref = "mlkitGenAi" }
 genai-proofreading = { module = "com.google.mlkit:genai-proofreading", version.ref = "mlkitGenAi" }

--- a/ai-catalog/samples/imagen/src/main/java/com/android/ai/samples/imagen/ImagenViewModel.kt
+++ b/ai-catalog/samples/imagen/src/main/java/com/android/ai/samples/imagen/ImagenViewModel.kt
@@ -23,11 +23,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.Firebase
-import com.google.firebase.vertexai.type.ImagenAspectRatio
-import com.google.firebase.vertexai.type.ImagenGenerationConfig
-import com.google.firebase.vertexai.type.ImagenImageFormat
+import com.google.firebase.ai.type.ImagenAspectRatio
+import com.google.firebase.ai.type.ImagenGenerationConfig
+import com.google.firebase.ai.type.ImagenImageFormat
 import com.google.firebase.vertexai.type.PublicPreviewAPI
-import com.google.firebase.vertexai.vertexAI
+import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.GenerativeBackend
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -41,7 +42,7 @@ class ImagenViewModel @Inject constructor(): ViewModel() {
     val isGenerating: LiveData<Boolean> = _isGenerating
 
     @OptIn(PublicPreviewAPI::class)
-    private val imagenModel = Firebase.vertexAI.imagenModel(
+    private val imagenModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).imagenModel(
         modelName = "imagen-3.0-generate-002",
         generationConfig = ImagenGenerationConfig(
             numberOfImages = 1,


### PR DESCRIPTION
This commit applies the initial changes to migrate from the firebase-vertexai SDK to the new firebase-ai (Firebase AI Logic SDK).

Key changes include:

1.  Updated `ai-catalog/gradle/libs.versions.toml`:
    *   Bumped `firebaseBom` to `33.14.0`.
    *   Switched `firebase-vertexai` to `firebase-ai`.
2.  Updated `ai-catalog/app/build.gradle.kts`:
    *   Changed dependency to `libs.firebase.ai`.
3.  Updated AI SDK usage in the Imagen sample:
    *   Modified `ai-catalog/samples/imagen/src/main/java/com/android/ai/samples/imagen/ImagenViewModel.kt` to use the new `firebase-ai` SDK, including import changes and updating the ImagenModel initialization to use `Firebase.ai(backend = GenerativeBackend.vertexAI()).imagenModel(...)`.

The `core/network/build.gradle.kts` and a central `FirebaseAiDataSource.kt` as seen in the reference PR for `androidify` were not found in this repository's structure. The Imagen-specific AI logic was updated directly in its ViewModel.

Further steps, including updating the README.md, remain.