### PR TITLE
[Jules] Refactor to use Firebase AI Logic SDK

### DIFF
--- a/ai-catalog/app/build.gradle.kts
+++ b/ai-catalog/app/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.vertexai)
+    implementation(libs.firebase.ai)
     ksp(libs.hilt.compiler)
 
     implementation(project(":samples:gemini-multimodal"))

--- a/ai-catalog/gradle/libs.versions.toml
+++ b/ai-catalog/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.8.0"
 coilCompose = "3.1.0"
-firebaseBom = "33.12.0"
+firebaseBom = "33.14.0"
 mlkitGenAi = "1.0.0-beta1"
 kotlin = "2.1.0"
 coreKtx = "1.15.0"
@@ -31,7 +31,7 @@ uiToolingPreviewAndroid = "1.8.1"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
-firebase-vertexai = { group = "com.google.firebase", name = "firebase-vertexai" }
+firebase-ai = { module = "com.google.firebase:firebase-ai" }
 firebase-common-ktx = { group = "com.google.firebase", name = "firebase-common-ktx", version.ref = "firebaseCommonKtx" }
 genai-image-description = { module = "com.google.mlkit:genai-image-description", version.ref = "mlkitGenAi" }
 genai-proofreading = { module = "com.google.mlkit:genai-proofreading", version.ref = "mlkitGenAi" }

--- a/ai-catalog/samples/gemini-chatbot/build.gradle.kts
+++ b/ai-catalog/samples/gemini-chatbot/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material.icons.extended)
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.vertexai)
+    implementation(libs.firebase.ai)
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.androidx.runtime.livedata)

--- a/ai-catalog/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/GeminiChatbotViewModel.kt
+++ b/ai-catalog/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/GeminiChatbotViewModel.kt
@@ -20,12 +20,13 @@ package com.android.ai.samples.geminichatbot
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.Firebase
-import com.google.firebase.vertexai.type.HarmBlockThreshold
-import com.google.firebase.vertexai.type.HarmCategory
-import com.google.firebase.vertexai.type.SafetySetting
-import com.google.firebase.vertexai.type.content
-import com.google.firebase.vertexai.type.generationConfig
-import com.google.firebase.vertexai.vertexAI
+import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.HarmBlockThreshold
+import com.google.firebase.ai.type.HarmCategory
+import com.google.firebase.ai.type.SafetySetting
+import com.google.firebase.ai.type.content
+import com.google.firebase.ai.type.generationConfig
+import com.google.firebase.ai.type.GenerativeBackend
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -37,7 +38,7 @@ class GeminiChatbotViewModel @Inject constructor(): ViewModel() {
     val messageList: StateFlow<List<ChatMessage>> = _messageList
 
     private val generativeModel by lazy {
-        Firebase.vertexAI.generativeModel(
+        Firebase.ai(backend = GenerativeBackend.vertexAI()).generativeModel(
             "gemini-2.0-flash",
             generationConfig = generationConfig {
                 temperature = 0.9f

--- a/ai-catalog/samples/gemini-multimodal/build.gradle.kts
+++ b/ai-catalog/samples/gemini-multimodal/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.material.icons.extended)
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.vertexai)
+    implementation(libs.firebase.ai)
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.androidx.runtime.livedata)

--- a/ai-catalog/samples/gemini-multimodal/src/main/java/com/android/ai/samples/geminimultimodal/GeminiMultimodalViewModel.kt
+++ b/ai-catalog/samples/gemini-multimodal/src/main/java/com/android/ai/samples/geminimultimodal/GeminiMultimodalViewModel.kt
@@ -21,12 +21,13 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.Firebase
-import com.google.firebase.vertexai.type.HarmBlockThreshold
-import com.google.firebase.vertexai.type.HarmCategory
-import com.google.firebase.vertexai.type.SafetySetting
-import com.google.firebase.vertexai.type.content
-import com.google.firebase.vertexai.type.generationConfig
-import com.google.firebase.vertexai.vertexAI
+import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.HarmBlockThreshold
+import com.google.firebase.ai.type.HarmCategory
+import com.google.firebase.ai.type.SafetySetting
+import com.google.firebase.ai.type.content
+import com.google.firebase.ai.type.generationConfig
+import com.google.firebase.ai.type.GenerativeBackend
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -41,7 +42,7 @@ class GeminiMultimodalViewModel @Inject constructor(): ViewModel() {
     val isGenerating: LiveData<Boolean> = _isGenerating
 
     private val generativeModel by lazy {
-        Firebase.vertexAI.generativeModel(
+        Firebase.ai(backend = GenerativeBackend.vertexAI()).generativeModel(
             "gemini-2.0-flash",
             generationConfig = generationConfig {
                 temperature = 0.9f

--- a/ai-catalog/samples/gemini-video-summarization/build.gradle.kts
+++ b/ai-catalog/samples/gemini-video-summarization/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview.android)
     ksp(libs.hilt.compiler)
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.vertexai)
+    implementation(libs.firebase.ai)
 
     // Media3 ExoPlayer
     implementation(libs.androidx.media3.exoplayer)

--- a/ai-catalog/samples/gemini-video-summarization/src/main/java/com/android/ai/samples/geminivideosummary/viewmodel/VideoSummarizationViewModel.kt
+++ b/ai-catalog/samples/gemini-video-summarization/src/main/java/com/android/ai/samples/geminivideosummary/viewmodel/VideoSummarizationViewModel.kt
@@ -22,8 +22,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.Firebase
-import com.google.firebase.vertexai.type.content
-import com.google.firebase.vertexai.vertexAI
+import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.content
+import com.google.firebase.ai.type.GenerativeBackend
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -50,7 +51,7 @@ class VideoSummarizationViewModel @Inject constructor() : ViewModel() {
             _outputText.value = OutputTextState.Loading
 
             try {
-                val generativeModel = Firebase.vertexAI.generativeModel("gemini-2.0-flash")
+                val generativeModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).generativeModel("gemini-2.0-flash")
 
                 val requestContent = content {
                     fileData(videoSource.toString(), "video/mp4")

--- a/ai-catalog/samples/imagen/build.gradle.kts
+++ b/ai-catalog/samples/imagen/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material.icons.extended)
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.vertexai)
+    implementation(libs.firebase.ai)
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.androidx.runtime.livedata)

--- a/ai-catalog/samples/imagen/src/main/java/com/android/ai/samples/imagen/ImagenViewModel.kt
+++ b/ai-catalog/samples/imagen/src/main/java/com/android/ai/samples/imagen/ImagenViewModel.kt
@@ -23,11 +23,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.Firebase
-import com.google.firebase.vertexai.type.ImagenAspectRatio
-import com.google.firebase.vertexai.type.ImagenGenerationConfig
-import com.google.firebase.vertexai.type.ImagenImageFormat
-import com.google.firebase.vertexai.type.PublicPreviewAPI
-import com.google.firebase.vertexai.vertexAI
+import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.GenerativeBackend
+import com.google.firebase.ai.type.ImagenAspectRatio
+import com.google.firebase.ai.type.ImagenGenerationConfig
+import com.google.firebase.ai.type.ImagenImageFormat
+import com.google.firebase.ai.type.PublicPreviewAPI
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -41,7 +42,7 @@ class ImagenViewModel @Inject constructor(): ViewModel() {
     val isGenerating: LiveData<Boolean> = _isGenerating
 
     @OptIn(PublicPreviewAPI::class)
-    private val imagenModel = Firebase.vertexAI.imagenModel(
+    private val imagenModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).imagenModel(
         modelName = "imagen-3.0-generate-002",
         generationConfig = ImagenGenerationConfig(
             numberOfImages = 1,

--- a/ai-catalog/samples/magic-selfie/build.gradle.kts
+++ b/ai-catalog/samples/magic-selfie/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material.icons.extended)
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.vertexai)
+    implementation(libs.firebase.ai)
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.androidx.runtime.livedata)

--- a/ai-catalog/samples/magic-selfie/src/main/java/com/android/ai/samples/magicselfie/MagicSelfieViewModel.kt
+++ b/ai-catalog/samples/magic-selfie/src/main/java/com/android/ai/samples/magicselfie/MagicSelfieViewModel.kt
@@ -25,11 +25,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.Firebase
-import com.google.firebase.vertexai.type.ImagenAspectRatio
-import com.google.firebase.vertexai.type.ImagenGenerationConfig
-import com.google.firebase.vertexai.type.ImagenImageFormat
-import com.google.firebase.vertexai.type.PublicPreviewAPI
-import com.google.firebase.vertexai.vertexAI
+import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.GenerativeBackend
+import com.google.firebase.ai.type.ImagenAspectRatio
+import com.google.firebase.ai.type.ImagenGenerationConfig
+import com.google.firebase.ai.type.ImagenImageFormat
+import com.google.firebase.ai.type.PublicPreviewAPI
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.segmentation.subject.SubjectSegmentation
 import com.google.mlkit.vision.segmentation.subject.SubjectSegmenterOptions
@@ -48,7 +49,7 @@ class MagicSelfieViewModel @Inject constructor(): ViewModel() {
     private val _progress = MutableLiveData<String?>(null)
     val progress: LiveData<String?> = _progress
 
-    private val imagenModel = Firebase.vertexAI.imagenModel(
+    private val imagenModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).imagenModel(
         modelName = "imagen-3.0-generate-002",
         generationConfig = ImagenGenerationConfig(
             numberOfImages = 1,


### PR DESCRIPTION
Tested: Ran app on Pixel 9 and tried all Firebase-related samples in catalog

Prompt used with Jules:
```
can you refactor this repository to use the latest version if Firebase AI Logic SDK instead of the current vertex-ai-in-firebase SDK

this is the pull request you can reference to do this https://github.com/android/androidify/pull/9.

you should look in the following samples: gemini-chatbot, gemini-multimodal, gemini-video-summarization, imagen, magic-selfie
```