### PR TITLE
Update Google AI Edge SDK docs url in README

### DIFF
--- a/gemini-nano/README.md
+++ b/gemini-nano/README.md
@@ -1,6 +1,6 @@
 # Google AI Edge SDK Quickstart
 
-*   [Read more about Google AI Edge SDK](https://developer.android.com/ai/gemini-nano-experimental)
+*   [Read more about Google AI Edge SDK](https://developer.android.com/ai/gemini-nano/ai-edge-sdk)
 
 This sample app demonstrates how to use the Google AI Edge SDK to access Gemini
 Nano on Android.


### PR DESCRIPTION
Fix Google AI Edge SDK docs url in gemini-nano/README.md
Curren [url](https://developer.android.com/ai/gemini-nano-experimental) sends user to `404 | Page not found`