### PR TITLE
Refactor GeminiChatbot UI and ViewModel

### DIFF
--- a/ai-catalog/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/ChatMessage.kt
+++ b/ai-catalog/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/ChatMessage.kt
@@ -20,6 +20,6 @@ import android.net.Uri
 data class ChatMessage(
     val text: String,
     val timestamp: Long,
-    val isIncoming: Boolean,
-    val senderIconUrl: Uri?,
+    val isIncoming: Boolean = false,
+    val senderIconUrl: Uri? = null,
 )

--- a/ai-catalog/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/InputBar.kt
+++ b/ai-catalog/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/InputBar.kt
@@ -16,13 +16,13 @@
 package com.android.ai.samples.geminichatbot
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -38,19 +38,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 
 @Composable
 internal fun InputBar(
-    modifier: Modifier = Modifier,
     value: String,
     placeholder: String,
-    contentPadding: PaddingValues,
     sendEnabled: Boolean,
     onInputChanged: (String) -> Unit,
     onSendClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Surface(
         modifier = modifier,
@@ -58,7 +58,6 @@ internal fun InputBar(
     ) {
         Row(
             modifier = Modifier
-                .padding(contentPadding)
                 .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -68,7 +67,8 @@ internal fun InputBar(
                 onValueChange = onInputChanged,
                 modifier = Modifier
                     .weight(1f)
-                    .height(56.dp),
+                    .defaultMinSize(minHeight = 56.dp)
+                    .wrapContentHeight(),
                 keyboardOptions = KeyboardOptions(
                     capitalization = KeyboardCapitalization.Sentences,
                     imeAction = ImeAction.Send,
@@ -92,7 +92,7 @@ internal fun InputBar(
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.Send,
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.send),
                 )
             }
         }

--- a/ai-catalog/samples/gemini-chatbot/src/main/res/values/strings.xml
+++ b/ai-catalog/samples/gemini-chatbot/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="see_code">See code</string>
     <string name="dismiss_button">Dismiss</string>
     <string name="error">Error</string>
+    <string name="send">Send</string>
 </resources>


### PR DESCRIPTION
This commit refactors the GeminiChatbot improved state management and fixes some bugs with the UI/

Key changes:

*   **ViewModel State:**
    *   Replaced sealed class `GeminiChatbotUiState` with a data class `GeminiChatbotUiState` containing `messages` and `geminiMessageState`.
    *   Introduced `GeminiMessageState` sealed interface (`WaitingForMessage`, `Generating`, `Error`) to represent the state of Gemini API calls.
    *   Simplified message handling by prepending new messages to the existing list and updating the state accordingly.
    *   `dismissError` now transitions `geminiMessageState` to `WaitingForMessage`.
*   **UI (GeminiChatbotScreen.kt):**
    *   Adapted to the new `GeminiChatbotUiState` and `GeminiMessageState`.
    *   Applied `imePadding()` to the `Scaffold` to adjust for the on-screen keyboard.
    *   TopAppBar container and title colors are now `primaryContainer` and `onPrimaryContainer` respectively.
    *   `MessageList` now takes horizontal padding and messages are directly passed from `uiState`.
    *   `MessageBubble` is now wrapped in a `Box` to allow for `Alignment.CenterStart` or `Alignment.CenterEnd` based on `message.isIncoming`, and has a `widthIn(max = 300.dp)` constraint.
    *   Removed a custom `PaddingValues.copy` extension function.
*   **InputBar.kt:**
    *   Removed `contentPadding` parameter as padding is handled by the parent.
    *   `TextField` now uses `defaultMinSize(minHeight = 56.dp)` and `wrapContentHeight()` for better sizing.
    *   Added content description to the send `Icon`.
*   **ChatMessage.kt:**

<img width="540" height="1212" alt="Screenshot_20250725_203241" src="https://github.com/user-attachments/assets/32d4173a-3869-44aa-8b7e-c70d19fb4a38" />

