### PR TITLE
Fix image editing sample

### DIFF
--- a/ai-catalog/samples/imagen-editing/src/main/java/com/android/ai/samples/imagenediting/ui/ImagenEditingScreen.kt
+++ b/ai-catalog/samples/imagen-editing/src/main/java/com/android/ai/samples/imagenediting/ui/ImagenEditingScreen.kt
@@ -232,7 +232,7 @@ private fun ImagenEditingScreenContent(
                                 bitmap = uiState.maskBitmap.asImageBitmap(),
                                 contentDescription = stringResource(R.string.editing_generated_mask),
                                 modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop,
+                                contentScale = ContentScale.Fit,
                                 colorFilter = ColorFilter.tint(Color.Red.copy(alpha = 0.5f)),
                             )
                         }


### PR DESCRIPTION
The masking feature of the image editing sample doesn't work perfectly after the redesign. When masking a portion of the image, after pressing ok when the masking changes to the red color, it moves and doesn't mask the original assigned portion of the image.

This is because of the content scale. I changed it to "FIT" which seems to fix the issue.