### PR TITLE
Fix Gemini Live delete tool calling

### DIFF
--- a/samples/gemini-live-todo/src/main/java/com/android/ai/samples/geminilivetodo/data/Todo.kt
+++ b/samples/gemini-live-todo/src/main/java/com/android/ai/samples/geminilivetodo/data/Todo.kt
@@ -15,10 +15,11 @@
  */
 package com.android.ai.samples.geminilivetodo.data
 
-import java.util.UUID.randomUUID
+import kotlin.random.Random
+
 
 data class Todo(
-    val id: Long = randomUUID().mostSignificantBits,
+    val id: Int = Random.nextInt(),
     val task: String,
     val isCompleted: Boolean = false,
 )

--- a/samples/gemini-live-todo/src/main/java/com/android/ai/samples/geminilivetodo/data/TodoRepository.kt
+++ b/samples/gemini-live-todo/src/main/java/com/android/ai/samples/geminilivetodo/data/TodoRepository.kt
@@ -41,22 +41,24 @@ class TodoRepository @Inject constructor() {
 
     fun getTodoList(): List<Todo> = _todos.value
 
-    fun addTodo(taskDescription: String) {
+    fun addTodo(taskDescription: String) : Int? {
         if (taskDescription.isNotBlank()) {
             val newTodo = Todo(task = taskDescription)
             _todos.update { currentList ->
                 currentList + newTodo
             }
+            return newTodo.id
         }
+        return null
     }
 
-    fun removeTodo(todoId: Long) {
+    fun removeTodo(todoId: Int) {
         _todos.update { currentList ->
             currentList.filterNot { it.id == todoId }
         }
     }
 
-    fun toggleTodoStatus(todoId: Long) {
+    fun toggleTodoStatus(todoId: Int) {
         _todos.update { currentList ->
             currentList.map { todo ->
                 if (todo.id == todoId) {


### PR DESCRIPTION
Fix Gemini Live delete tool calling in the Gemini Live Todo sample

Extremely long integer `Id`s were converted to scientific notation (eg: `-6371298176326611879` became `-6.371298176326612e+18`) when passed to gemini, causing item removal to crash.

Key changes:
- Item `id`s are now handled as `int` instead of `long` (robust for our expected item count...).
- The item insertion function now returns the ID of the newly created item. This remove the need for the model to call `getTodoList` just to discover the new `id`.