### PR TITLE
Update source code URLs in samples

### DIFF
--- a/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/GeminiChatbotScreen.kt
+++ b/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/GeminiChatbotScreen.kt
@@ -87,7 +87,7 @@ private fun GeminiChatbotScreen(uiState: GeminiChatbotUiState, onSendMessage: (S
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.geminichatbot_title),
                 sampleDescription = stringResource(R.string.geminichatbot_description),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/gemini-chatbot",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/gemini-chatbot",
                 modifier = Modifier.background(MaterialTheme.colorScheme.surface),
                 onBackClick = { backDispatcher?.onBackPressed() },
                 topAppBarState = topAppBarState,

--- a/samples/gemini-image-chat/src/main/java/com/android/ai/samples/geminiimagechat/GeminiImageChatScreen.kt
+++ b/samples/gemini-image-chat/src/main/java/com/android/ai/samples/geminiimagechat/GeminiImageChatScreen.kt
@@ -143,7 +143,7 @@ private fun GeminiImageChatScreen(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.gemini_image_chat_title),
                 sampleDescription = stringResource(R.string.gemini_image_chat_description),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/gemini-image-chat",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/gemini-image-chat",
                 onBackClick = { backDispatcher?.onBackPressed() },
                 topAppBarState = topAppBarState,
                 scrollBehavior = scrollBehavior,

--- a/samples/gemini-live-todo/src/main/java/com/android/ai/samples/geminilivetodo/ui/TodoScreen.kt
+++ b/samples/gemini-live-todo/src/main/java/com/android/ai/samples/geminilivetodo/ui/TodoScreen.kt
@@ -90,7 +90,7 @@ fun TodoScreen(viewModel: TodoScreenViewModel = hiltViewModel()) {
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.gemini_live_title),
                 sampleDescription = stringResource(R.string.gemini_live_subtitle),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/gemini-live-todo",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/gemini-live-todo",
                 topAppBarState = topAppBarState,
                 scrollBehavior = scrollBehavior,
                 onBackClick = { backDispatcher?.onBackPressed() },

--- a/samples/gemini-multimodal/src/main/java/com/android/ai/samples/geminimultimodal/ui/GeminiMultimodalScreen.kt
+++ b/samples/gemini-multimodal/src/main/java/com/android/ai/samples/geminimultimodal/ui/GeminiMultimodalScreen.kt
@@ -127,7 +127,7 @@ private fun GeminiMultimodalScreen(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.geminimultimodal_title),
                 sampleDescription = stringResource(R.string.geminimultimodal_subtitle),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/gemini-multimodal",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/gemini-multimodal",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },

--- a/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/ui/VideoMetadataCreationScreen.kt
+++ b/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/ui/VideoMetadataCreationScreen.kt
@@ -114,7 +114,7 @@ private fun VideoMetadataCreationScreen(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.video_metadata_creation_title),
                 sampleDescription = stringResource(R.string.video_metadata_creation_title),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/gemini-video-metadata-creation",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/gemini-video-metadata-creation",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },

--- a/samples/gemini-video-summarization/src/main/java/com/android/ai/samples/geminivideosummary/ui/VideoSummarizationScreen.kt
+++ b/samples/gemini-video-summarization/src/main/java/com/android/ai/samples/geminivideosummary/ui/VideoSummarizationScreen.kt
@@ -150,7 +150,7 @@ private fun VideoSummarizationScreen(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.video_summarization_title),
                 sampleDescription = stringResource(R.string.video_summarization_description),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/gemini-video-summarization",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/gemini-video-summarization",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },

--- a/samples/genai-image-description/src/main/java/com/android/ai/samples/genai_image_description/GenAIImageDescriptionScreen.kt
+++ b/samples/genai-image-description/src/main/java/com/android/ai/samples/genai_image_description/GenAIImageDescriptionScreen.kt
@@ -109,7 +109,7 @@ private fun GenAIImageDescriptionScreen(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.genai_image_description_title),
                 sampleDescription = stringResource(R.string.genai_image_description_subtitle),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/genai-image-description",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/genai-image-description",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },

--- a/samples/genai-summarization/src/main/java/com/android/ai/samples/genai_summarization/GenAISummarizationScreen.kt
+++ b/samples/genai-summarization/src/main/java/com/android/ai/samples/genai_summarization/GenAISummarizationScreen.kt
@@ -99,7 +99,7 @@ fun GenAISummarizationContent(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.genai_summarization_title_bar),
                 sampleDescription = stringResource(R.string.genai_summarization_description),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/genai-summarization",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/genai-summarization",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },

--- a/samples/genai-writing-assistance/src/main/java/com/android/ai/samples/genai_writing_assistance/GenAIWritingAssistanceScreen.kt
+++ b/samples/genai-writing-assistance/src/main/java/com/android/ai/samples/genai_writing_assistance/GenAIWritingAssistanceScreen.kt
@@ -138,7 +138,7 @@ fun GenAIWritingAssistanceContent(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.genai_writing_assistance_title_bar),
                 sampleDescription = stringResource(R.string.genai_writing_assistance_description),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/genai-writing-assistance",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/genai-writing-assistance",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },

--- a/samples/imagen-editing/src/main/java/com/android/ai/samples/imagenediting/ui/ImagenEditingScreen.kt
+++ b/samples/imagen-editing/src/main/java/com/android/ai/samples/imagenediting/ui/ImagenEditingScreen.kt
@@ -107,7 +107,7 @@ private fun ImagenEditingScreenContent(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.editing_title_image_generation_title),
                 sampleDescription = stringResource(R.string.editing_title_image_generation_subtitle),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/imagen-editing",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/imagen-editing",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },

--- a/samples/imagen/src/main/java/com/android/ai/samples/imagen/ui/ImagenScreen.kt
+++ b/samples/imagen/src/main/java/com/android/ai/samples/imagen/ui/ImagenScreen.kt
@@ -89,7 +89,7 @@ private fun ImagenScreen(uiState: ImagenUIState, onGenerateClick: (String) -> Un
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.title_image_generation_screen),
                 sampleDescription = stringResource(R.string.subtitle_image_generation_screen),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/imagen",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/imagen",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },

--- a/samples/magic-selfie/src/main/java/com/android/ai/samples/magicselfie/ui/MagicSelfieScreen.kt
+++ b/samples/magic-selfie/src/main/java/com/android/ai/samples/magicselfie/ui/MagicSelfieScreen.kt
@@ -157,7 +157,7 @@ private fun MagicSelfieScreen(
             SampleDetailTopAppBar(
                 sampleName = stringResource(R.string.magic_selfie_title),
                 sampleDescription = stringResource(R.string.magic_selfie_subtitle),
-                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/ai-catalog/samples/magic-selfie",
+                sourceCodeUrl = "https://github.com/android/ai-samples/tree/main/samples/magic-selfie",
                 onBackClick = { backDispatcher?.onBackPressed() },
             )
         },


### PR DESCRIPTION
This commit updates the source code URLs in the
SampleDetailTopAppBar of various sample applications. The URLs were previously pointing to the ai-catalog directory, which has been moved to the samples directory.

- Update GeminiChatbotScreen.kt
- Update GeminiImageChatScreen.kt
- Update TodoScreen.kt
- Update GeminiMultimodalScreen.kt
- Update VideoMetadataCreationScreen.kt
- Update VideoSummarizationScreen.kt
- Update GenAIImageDescriptionScreen.kt
- Update GenAISummarizationScreen.kt
- Update GenAIWritingAssistanceScreen.kt
- Update ImagenEditingScreen.kt
- Update ImagenScreen.kt
- Update MagicSelfieScreen.kt