### PR TITLE
Imagen model update

### DIFF
--- a/samples/imagen-editing/src/main/java/com/android/ai/samples/imagenediting/data/ImagenEditingDataSource.kt
+++ b/samples/imagen-editing/src/main/java/com/android/ai/samples/imagenediting/data/ImagenEditingDataSource.kt
@@ -45,7 +45,7 @@ import javax.inject.Singleton
 @Singleton
 class ImagenEditingDataSource @Inject constructor() {
     private companion object {
-        const val IMAGEN_MODEL_NAME = "imagen-4.0-ultra-generate-001"
+        const val IMAGEN_MODEL_NAME = "imagen-4.0-generate-001"
         const val IMAGEN_EDITING_MODEL_NAME = "imagen-3.0-capability-001"
         const val DEFAULT_EDIT_STEPS = 50
         const val DEFAULT_STYLE_STRENGTH = 1

--- a/samples/imagen/src/main/java/com/android/ai/samples/imagen/data/ImagenDataSource.kt
+++ b/samples/imagen/src/main/java/com/android/ai/samples/imagen/data/ImagenDataSource.kt
@@ -30,7 +30,7 @@ import javax.inject.Singleton
 class ImagenDataSource @Inject constructor() {
     @OptIn(PublicPreviewAPI::class)
     private val imagenModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).imagenModel(
-        modelName = "imagen-4.0-generate-preview-06-06",
+        modelName = "imagen-4.0-generate-001",
         generationConfig = ImagenGenerationConfig(
             numberOfImages = 1,
             aspectRatio = ImagenAspectRatio.SQUARE_1x1,

--- a/samples/magic-selfie/README.md
+++ b/samples/magic-selfie/README.md
@@ -4,7 +4,7 @@ This sample is part of the [AI Sample Catalog](../../). To build and run this sa
 
 ## Description
 
-This sample demonstrates how to create a "magic selfie" by replacing the background of a user's photo with a generated image. It uses the ML Kit Subject Segmentation API to isolate the user from their original background and the Imagen API to generate a new background from a text prompt.
+This sample demonstrates how to create a "magic selfie" by replacing the background of a user's photo with a generated image. It uses the ML Kit Subject Segmentation API to isolate the user from their original background and the Imagen model to generate a new background from a text prompt.
 
 <div style="text-align: center;">
 <img width="320" alt="Magic Selfie in action" src="magic_selfie.png" />

--- a/samples/magic-selfie/src/main/java/com/android/ai/samples/magicselfie/data/MagicSelfieRepository.kt
+++ b/samples/magic-selfie/src/main/java/com/android/ai/samples/magicselfie/data/MagicSelfieRepository.kt
@@ -37,7 +37,7 @@ import kotlin.math.roundToInt
 class MagicSelfieRepository @Inject constructor() {
     @OptIn(PublicPreviewAPI::class)
     private val imagenModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).imagenModel(
-        modelName = "imagen-4.0-generate-preview-06-06",
+        modelName = "imagen-4.0-generate-001",
         generationConfig = ImagenGenerationConfig(
             numberOfImages = 1,
             aspectRatio = ImagenAspectRatio.PORTRAIT_3x4,


### PR DESCRIPTION
Update the `imagen-generate` models as the `-preview-06-06` model is going away.

I am also downgrading the `imagen-4.0-ultra-generate-001` in the imagen editing sample to `imagen-4.0-generate-001` since the sample doesn't benefit from the specs of ultra.