### PR TITLE
refactor(*): use the latest Gemini models (3.6 Flash, 3.5 Flash Lite and Nano Banana)

### DIFF
--- a/ai-sample-catalog/gradle.properties
+++ b/ai-sample-catalog/gradle.properties
@@ -24,3 +24,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/ai-sample-catalog/gradle.properties
+++ b/ai-sample-catalog/gradle.properties
@@ -24,5 +24,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-# Enabled parallel sync for Gradle 9.4+
-org.gradle.tooling.parallel=true

--- a/ai-sample-catalog/samples/gemini-chatbot/README.md
+++ b/ai-sample-catalog/samples/gemini-chatbot/README.md
@@ -18,7 +18,7 @@ Here is the key snippet of code that calls the generative model:
 
 ```kotlin
 private val generativeModel by lazy {
-    Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel("gemini-2.5-flash")
+    Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel("gemini-3.6-flash")
 }
 private val chat = generativeModel.startChat()
 

--- a/ai-sample-catalog/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/GeminiChatbotViewModel.kt
+++ b/ai-sample-catalog/samples/gemini-chatbot/src/main/java/com/android/ai/samples/geminichatbot/GeminiChatbotViewModel.kt
@@ -50,7 +50,7 @@ class GeminiChatbotViewModel @Inject constructor() : ViewModel() {
 
     private val generativeModel by lazy {
         Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
-            "gemini-2.5-flash",
+            "gemini-3.6-flash",
             generationConfig = generationConfig {
                 temperature = 0.9f
                 topK = 32

--- a/ai-sample-catalog/samples/gemini-hybrid/README.md
+++ b/ai-sample-catalog/samples/gemini-hybrid/README.md
@@ -18,7 +18,7 @@ Here is how the model is instantiated to leverage hybrid inference:
 ```kotlin
 val model = Firebase.ai(backend = GenerativeBackend.googleAI())
                 .generativeModel(
-                    "gemini-2.5-flash-lite",
+                    "gemini-3.5-flash-lite",
                     onDeviceConfig = OnDeviceConfig(mode = InferenceMode.PREFER_ON_DEVICE)
                 )
 

--- a/ai-sample-catalog/samples/gemini-hybrid/src/main/java/com/android/ai/samples/geminihybrid/GeminiHybridViewModel.kt
+++ b/ai-sample-catalog/samples/gemini-hybrid/src/main/java/com/android/ai/samples/geminihybrid/GeminiHybridViewModel.kt
@@ -79,7 +79,7 @@ class GeminiHybridViewModel @Inject constructor() : ViewModel() {
             try {
                 val model = Firebase.ai(backend = GenerativeBackend.googleAI())
                     .generativeModel(
-                        "gemini-2.5-flash-lite",
+                        "gemini-3.5-flash-lite",
                         onDeviceConfig = OnDeviceConfig(
                             mode = InferenceMode.ONLY_ON_DEVICE,
                             modelOption = OnDeviceModelOption.PREVIEW,
@@ -162,7 +162,7 @@ class GeminiHybridViewModel @Inject constructor() : ViewModel() {
 
                 val model = Firebase.ai(backend = GenerativeBackend.googleAI())
                     .generativeModel(
-                        "gemini-2.5-flash-lite",
+                        "gemini-3.5-flash-lite",
                         onDeviceConfig = OnDeviceConfig(
                             mode = _uiState.value.selectedMode,
                             modelOption = _uiState.value.selectedModelOption,
@@ -235,7 +235,7 @@ class GeminiHybridViewModel @Inject constructor() : ViewModel() {
 
                 val model = Firebase.ai(backend = GenerativeBackend.googleAI())
                     .generativeModel(
-                        "gemini-2.5-flash-lite",
+                        "gemini-3.5-flash-lite",
                         onDeviceConfig = OnDeviceConfig(
                             mode = _uiState.value.selectedMode,
                             modelOption = _uiState.value.selectedModelOption,

--- a/ai-sample-catalog/samples/gemini-image-chat/README.md
+++ b/ai-sample-catalog/samples/gemini-image-chat/README.md
@@ -17,7 +17,7 @@ The application uses the Firebase AI SDK (see [How to run](../../#how-to-run)) f
 Here is how the model is instantiated:
 ```kotlin
  Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
-            "gemini-3-pro-image-preview",
+            "gemini-3-pro-image",
             generationConfig = generationConfig {
                 temperature = 0.9f
                 topK = 32

--- a/ai-sample-catalog/samples/gemini-image-chat/src/main/java/com/android/ai/samples/geminiimagechat/GeminiImageChatViewModel.kt
+++ b/ai-sample-catalog/samples/gemini-image-chat/src/main/java/com/android/ai/samples/geminiimagechat/GeminiImageChatViewModel.kt
@@ -53,7 +53,7 @@ class GeminiImageChatViewModel @Inject constructor() : ViewModel() {
 
     private val generativeModel by lazy {
         Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
-            "gemini-3-pro-image-preview",
+            "gemini-3-pro-image",
             generationConfig = generationConfig {
                 temperature = 0.9f
                 topK = 32

--- a/ai-sample-catalog/samples/gemini-multimodal/README.md
+++ b/ai-sample-catalog/samples/gemini-multimodal/README.md
@@ -19,7 +19,7 @@ Here is the key snippet of code that initializes the generative model:
 ```kotlin
 private val generativeModel by lazy {
     Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
-        "gemini-2.5-flash",
+        "gemini-3.6-flash",
         generationConfig = generationConfig {
             temperature = 0.9f
             topK = 32

--- a/ai-sample-catalog/samples/gemini-multimodal/src/main/java/com/android/ai/samples/geminimultimodal/data/GeminiDataSource.kt
+++ b/ai-sample-catalog/samples/gemini-multimodal/src/main/java/com/android/ai/samples/geminimultimodal/data/GeminiDataSource.kt
@@ -31,7 +31,7 @@ import javax.inject.Singleton
 class GeminiDataSource @Inject constructor() {
     private val generativeModel by lazy {
         Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
-            "gemini-2.5-flash",
+            "gemini-3.6-flash",
             generationConfig = generationConfig {
                 temperature = 0.9f
                 topK = 32

--- a/ai-sample-catalog/samples/gemini-video-metadata-creation/README.md
+++ b/ai-sample-catalog/samples/gemini-video-metadata-creation/README.md
@@ -19,7 +19,7 @@ Here is a key snippet of code that generates a video description:
 ```kotlin
 suspend fun generateDescription(videoUri: Uri): @Composable () -> Unit {
     val response = Firebase.ai(backend = GenerativeBackend.vertexAI())
-        .generativeModel(modelName = "gemini-2.5-flash")
+        .generativeModel(modelName = "gemini-3.6-flash")
         .generateContent(
             content {
                 fileData(videoUri.toString(), "video/mp4")

--- a/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateAccountTags.kt
+++ b/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateAccountTags.kt
@@ -57,7 +57,7 @@ private val accountTagsSchema = Schema.array(
  * for generating account tags.
  *
  * This model is specifically set up with:
- * - `modelName = "gemini-2.5-flash"`: Specifies the underlying Gemini model to use.
+ * - `modelName = "gemini-3.6-flash"`: Specifies the underlying Gemini model to use.
  * - `responseMimeType = "application/json"`:  Indicates that the model is expected to
  *   return its response in JSON format.
  * - `responseSchema = accountTagsSchema`: Defines the expected structure of the JSON
@@ -69,7 +69,7 @@ private val accountTagsSchema = Schema.array(
  */
 private val accountTagsModel = Firebase.ai(backend = GenerativeBackend.vertexAI())
     .generativeModel(
-        modelName = "gemini-2.5-flash",
+        modelName = "gemini-3.6-flash",
         // Tell Firebase AI the exact format of the response.
         generationConfig {
             responseMimeType = "application/json"

--- a/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateChapters.kt
+++ b/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateChapters.kt
@@ -56,13 +56,13 @@ private val chaptersSchema = Schema.array(
 /**
  * The configured generative model for creating video chapters.
  *
- * This model is initialized with the "gemini-2.5-flash" model name and
+ * This model is initialized with the "gemini-3.6-flash" model name and
  * configured to expect a JSON response. The `responseSchema` ensures that
  * the output conforms to the `Chapters` data structure.
  */
 private val chaptersModel = Firebase.ai(backend = GenerativeBackend.vertexAI())
     .generativeModel(
-        modelName = "gemini-2.5-flash",
+        modelName = "gemini-3.6-flash",
         // Tell Firebase AI the exact format of the response.
         generationConfig {
             responseMimeType = "application/json"

--- a/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateDescription.kt
+++ b/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateDescription.kt
@@ -42,7 +42,7 @@ import com.google.firebase.ai.type.content
  */
 suspend fun generateDescription(videoUri: Uri): @Composable () -> Unit {
     val response = Firebase.ai(backend = GenerativeBackend.vertexAI())
-        .generativeModel(modelName = "gemini-2.5-flash")
+        .generativeModel(modelName = "gemini-3.6-flash")
         .generateContent(
             content {
                 fileData(videoUri.toString(), "video/mp4")

--- a/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateHashtags.kt
+++ b/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateHashtags.kt
@@ -40,14 +40,14 @@ private val hashtagSchema = Schema.array(items = Schema.string("Hashtag"))
 /**
  * A generative model instance configured to generate hashtags for video content.
  *
- * This model uses the "gemini-2.5-flash" model from Vertex AI and is specifically configured
+ * This model uses the "gemini-3.6-flash" model from Vertex AI and is specifically configured
  * to return a JSON array of strings, where each string represents a hashtag.
  * The `responseMimeType` is set to "application/json" and the `responseSchema` defines
  * the expected output format as an array of strings with the item name "Hashtag".
  */
 private val hashtagsModel = Firebase.ai(backend = GenerativeBackend.vertexAI())
     .generativeModel(
-        modelName = "gemini-2.5-flash",
+        modelName = "gemini-3.6-flash",
         // Tell Firebase AI the exact format of the response.
         generationConfig {
             responseMimeType = "application/json"

--- a/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateLinks.kt
+++ b/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateLinks.kt
@@ -39,13 +39,13 @@ private val linksSchema = Schema.array(items = Schema.string("Link"))
  * The configured generative model for extracting links.
  *
  * This model is specifically configured to:
- * - Use the "gemini-2.5-flash" model.
+ * - Use the "gemini-3.6-flash" model.
  * - Expect a response in "application/json" format.
  * - Adhere to the `linksSchema`, which defines the expected JSON structure as an array of strings (links).
  */
 private val linksModel = Firebase.ai(backend = GenerativeBackend.vertexAI())
     .generativeModel(
-        modelName = "gemini-2.5-flash",
+        modelName = "gemini-3.6-flash",
         // Tell Firebase AI the exact format of the response.
         generationConfig {
             responseMimeType = "application/json"

--- a/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateThumbnails.kt
+++ b/ai-sample-catalog/samples/gemini-video-metadata-creation/src/main/java/com/android/ai/samples/geminivideometadatacreation/GenerateThumbnails.kt
@@ -39,13 +39,13 @@ private val thumbnailsSchema = Schema.array(items = Schema.long("thumbnail times
 
 /**
  * Initializes the generative model for thumbnail generation.
- * This model uses the "gemini-2.5-flash" model via the Vertex AI backend.
+ * This model uses the "gemini-3.6-flash" model via the Vertex AI backend.
  * It's configured to expect a JSON response with a specific schema (`thumbnailsSchema`)
  * defining an array of long integers representing thumbnail timestamps.
  */
 private val thumbnailsModel = Firebase.ai(backend = GenerativeBackend.vertexAI())
     .generativeModel(
-        modelName = "gemini-2.5-flash",
+        modelName = "gemini-3.6-flash",
         // Tell Firebase AI the exact format of the response.
         generationConfig {
             responseMimeType = "application/json"

--- a/ai-sample-catalog/samples/gemini-video-summarization/README.md
+++ b/ai-sample-catalog/samples/gemini-video-summarization/README.md
@@ -19,7 +19,7 @@ Here is the key snippet of code that calls the generative model:
 ```kotlin
 val generativeModel =
     Firebase.ai(backend = GenerativeBackend.vertexAI())
-        .generativeModel("gemini-2.5-flash")
+        .generativeModel("gemini-3.6-flash")
 
 val requestContent = content {
     fileData(videoSource.toString(), "video/mp4")

--- a/ai-sample-catalog/samples/gemini-video-summarization/src/main/java/com/android/ai/samples/geminivideosummary/viewmodel/VideoSummarizationViewModel.kt
+++ b/ai-sample-catalog/samples/gemini-video-summarization/src/main/java/com/android/ai/samples/geminivideosummary/viewmodel/VideoSummarizationViewModel.kt
@@ -75,7 +75,7 @@ class VideoSummarizationViewModel @Inject constructor() : ViewModel() {
             try {
                 val generativeModel =
                     Firebase.ai(backend = GenerativeBackend.vertexAI())
-                        .generativeModel("gemini-2.5-flash")
+                        .generativeModel("gemini-3.6-flash")
 
                 val requestContent = content {
                     fileData(videoSource.toString(), "video/mp4")

--- a/ai-sample-catalog/samples/magic-selfie/README.md
+++ b/ai-sample-catalog/samples/magic-selfie/README.md
@@ -4,7 +4,7 @@ This sample is part of the [AI Sample Catalog](../../). To build and run this sa
 
 ## Description
 
-This sample demonstrates how to create a "magic selfie" by replacing the background of a user's photo with a generated image. It uses the Nano Banana 2 (`gemini-3.1-flash-image-preview`) model to perform semantic image editing, transforming the background based on a text prompt while preserving the subject.
+This sample demonstrates how to create a "magic selfie" by replacing the background of a user's photo with a generated image. It uses the Nano Banana 2 (`gemini-3.1-flash-image`) model to perform semantic image editing, transforming the background based on a text prompt while preserving the subject.
 
 <div style="text-align: center;">
 <img width="320" alt="Magic Selfie in action" src="magic_selfie.png" />

--- a/ai-sample-catalog/samples/magic-selfie/src/main/java/com/android/ai/samples/magicselfie/data/MagicSelfieRepository.kt
+++ b/ai-sample-catalog/samples/magic-selfie/src/main/java/com/android/ai/samples/magicselfie/data/MagicSelfieRepository.kt
@@ -30,7 +30,7 @@ import javax.inject.Singleton
 class MagicSelfieRepository @Inject constructor() {
     private val generativeModel by lazy {
         Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
-            modelName = "gemini-3.1-flash-image-preview",
+            modelName = "gemini-3.1-flash-image",
             generationConfig = generationConfig {
                 responseModalities = listOf(ResponseModality.TEXT, ResponseModality.IMAGE)
             },

--- a/ai-sample-catalog/samples/nanobanana/src/main/java/com/android/ai/samples/nanobanana/data/NanobananaDataSource.kt
+++ b/ai-sample-catalog/samples/nanobanana/src/main/java/com/android/ai/samples/nanobanana/data/NanobananaDataSource.kt
@@ -29,7 +29,7 @@ import javax.inject.Singleton
 class NanobananaDataSource @Inject constructor() {
     private val generativeModel by lazy {
         Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
-            modelName = "gemini-3.1-flash-image-preview",
+            modelName = "gemini-3.1-flash-image",
             generationConfig = generationConfig {
                 responseModalities = listOf(ResponseModality.IMAGE)
             },

--- a/jetpacker/README.md
+++ b/jetpacker/README.md
@@ -101,8 +101,8 @@ JetPacker integrates local on-device AI capabilities using ML Kit. These feature
 
 ## Cloud-Hybrid & Online AI Features
 JetPacker also integrates online hybrid features using Firebase AI Logic (Gemini API) and ML Kit:
-- **ENABLE_MUSEUM_ASSISTANT**: Museum Assistant chatbot with URL, Maps, and Search grounding (uses Gemini 2.5 flash-lite).
-- **ENABLE_REVIEW_GENERATION**: Topic-selected review generator (uses Gemini 2.5 flash-lite on-device with cloud fallback).
+- **ENABLE_MUSEUM_ASSISTANT**: Museum Assistant chatbot with URL, Maps, and Search grounding (uses Gemini 3.6 flash-lite).
+- **ENABLE_REVIEW_GENERATION**: Topic-selected review generator (uses Gemini 3.5 flash-lite on-device with cloud fallback).
 - **Hotel Support Chat**: Receives hotel receptionist assistance with real-time ML Kit + Gemini translation.
 
 ## AppFunctions Integration

--- a/jetpacker/README.md
+++ b/jetpacker/README.md
@@ -101,7 +101,7 @@ JetPacker integrates local on-device AI capabilities using ML Kit. These feature
 
 ## Cloud-Hybrid & Online AI Features
 JetPacker also integrates online hybrid features using Firebase AI Logic (Gemini API) and ML Kit:
-- **ENABLE_MUSEUM_ASSISTANT**: Museum Assistant chatbot with URL, Maps, and Search grounding (uses Gemini 3.6 flash-lite).
+- **ENABLE_MUSEUM_ASSISTANT**: Museum Assistant chatbot with URL, Maps, and Search grounding (uses Gemini 3.5 flash-lite).
 - **ENABLE_REVIEW_GENERATION**: Topic-selected review generator (uses Gemini 3.5 flash-lite on-device with cloud fallback).
 - **Hotel Support Chat**: Receives hotel receptionist assistance with real-time ML Kit + Gemini translation.
 

--- a/jetpacker/android/feature/detail/hotel_chat/src/main/kotlin/com/example/jetpacker/feature/detail/hotel_chat/HotelSupportChatViewModel.kt
+++ b/jetpacker/android/feature/detail/hotel_chat/src/main/kotlin/com/example/jetpacker/feature/detail/hotel_chat/HotelSupportChatViewModel.kt
@@ -65,7 +65,7 @@ class HotelSupportChatViewModel(val hotelName: String = "Hotel", val language: S
   private val hybridTranslationModel =
     Firebase.ai(backend = GenerativeBackend.googleAI())
       .generativeModel(
-        modelName = "gemini-3-flash-preview",
+        modelName = "gemini-3.6-flash",
         onDeviceConfig = OnDeviceConfig(mode = InferenceMode.PREFER_ON_DEVICE),
       )
 
@@ -74,7 +74,7 @@ class HotelSupportChatViewModel(val hotelName: String = "Hotel", val language: S
   private val cloudTranslationModel =
     Firebase.ai(backend = GenerativeBackend.googleAI())
       .generativeModel(
-        modelName = "gemini-3-flash-preview", // Represents cloud TranslateGemma
+        modelName = "gemini-3.6-flash", // Represents cloud TranslateGemma
       )
 
   // Firebase AI for chat
@@ -87,7 +87,7 @@ class HotelSupportChatViewModel(val hotelName: String = "Hotel", val language: S
               "You are a helpful hotel receptionist at $hotelName only speaking $language. Answer politely in $language. The bar closes at 10pm and breakfast is from 7am to 10am. There's someone at the desk 24/7. You can retrieve your luggage from the storage room at the back of the lobby at any time."
             )
           },
-        modelName = "gemini-3-flash-preview",
+        modelName = "gemini-3.6-flash",
       )
 
   private val chat = generativeModel.startChat()

--- a/jetpacker/android/feature/detail/museum_assistant/src/main/kotlin/com/example/jetpacker/feature/detail/museum_assistant/ChatViewModel.kt
+++ b/jetpacker/android/feature/detail/museum_assistant/src/main/kotlin/com/example/jetpacker/feature/detail/museum_assistant/ChatViewModel.kt
@@ -73,7 +73,7 @@ constructor(savedStateHandle: SavedStateHandle, private val eventDao: EventDao) 
               "You are a helpful museum assistant, answering questions about a museum. Never use markdown, use plain text."
             )
           },
-        modelName = "gemini-3.1-flash-lite",
+        modelName = "gemini-3.5-flash-lite",
         tools = toolList,
       )
 

--- a/jetpacker/android/feature/detail/review/src/main/kotlin/com/example/jetpacker/feature/detail/review/ReviewScreenViewModel.kt
+++ b/jetpacker/android/feature/detail/review/src/main/kotlin/com/example/jetpacker/feature/detail/review/ReviewScreenViewModel.kt
@@ -72,7 +72,7 @@ class ReviewScreenViewModel @Inject constructor(savedStateHandle: SavedStateHand
   private val generativeModel =
     Firebase.ai(backend = GenerativeBackend.googleAI())
       .generativeModel(
-        modelName = "gemini-2.5-flash-lite",
+        modelName = "gemini-3.5-flash-lite",
         onDeviceConfig = OnDeviceConfig(mode = InferenceMode.PREFER_ON_DEVICE),
       )
 


### PR DESCRIPTION
This PR should update both the `ai-sample-catalog` and `jetpacker` to:
- use the latest Gemini models (3.6 Flash and 3.5 Flash Lite)
- use the stable versions of the Nano Banana models (rather than preview)